### PR TITLE
Widen engines range

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Lim Yao Jie",
   "license": "MIT",
   "engines": {
-    "node": "8.9.1"
+    "node": ">=8.9.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Hi! Tried to install the package, got the following message:

```
night-stalker@0.5.0: The engine "node" is incompatible with this module. 
   Expected version "8.9.1". Got "11.15.0"
```

My node version is 11. Could you also publish a new version, if you merge this PR, please?